### PR TITLE
Update schedule-ui.xml

### DIFF
--- a/schedule-ui.xml
+++ b/schedule-ui.xml
@@ -460,7 +460,7 @@
                     <!--     <line color="#000000" alpha="255" width="3" /> -->
                     <!--         <cornerradius>9</cornerradius> -->
                     <!-- </shape> -->
-                    <textarea name="channelnumber" from="basetextarea">
+                    <textarea name="buttontext" from="basetextarea">
                         <area>112,1,157,82</area>
                         <font>basesmall</font>
                         <font state="favourite">basesmallyellow</font>
@@ -469,7 +469,6 @@
                         <cutdown>no</cutdown>
                         <align>allcenter</align>
                         <multiline>yes</multiline>
-                        <template>%CHANNELNUMBER|\n%%CALLSIGN%</template>
                   </textarea>
                 </state>
                 <state name="selectedactive" from="active"/>


### PR DESCRIPTION
Changed "channel number" to "buttontext".  This allows user to control format via the TV->TV Settings->General->Channel Format preference.  This was only done for the "programguide-video" window (LiveTV guide) and not for "program guide" (Non LiveTV guide), as I am not sure where the format for the latter is set. 