### PR TITLE
Music and Stream Enhancements

### DIFF
--- a/base.xml
+++ b/base.xml
@@ -201,6 +201,38 @@
         <fill color="#FFFFFF" alpha="50" />
     </shape>
 
+    <!-- Base definition of a vertical scrollbar -->
+    <!-- moved earlier since basebuttonlist3 below needs this! -->
+
+    <scrollbar name="basevertscrollbar">
+        <area>1114,0,10,970</area>
+        <layout>vertical</layout>
+        <hidedelay>0</hidedelay>
+        <shape name="background">
+            <area>0,0,100%,100%</area>
+            <type>roundbox</type>
+            <line color="#000000" alpha="0" width="0" />
+            <fill color="#000000" alpha="0"/>
+            <cornerradius>5</cornerradius>
+        </shape>
+        <shape name="slider">
+            <area>0,0,100%,40</area>
+            <type>roundbox</type>
+            <line color="#ffffff" alpha="50" width="0" />
+            <fill color="#ffffff" alpha="50"/>
+            <cornerradius>5</cornerradius>
+        </shape>
+    </scrollbar>
+
+    <!-- Base definition of a horizontal scrollbar -->
+    <scrollbar name="basehorizscrollbar" from="basevertscrollbar">
+        <area>20,1030,1880,14</area>
+        <layout>horizontal</layout>
+        <shape name="slider">
+            <area>0,0,40,14</area>
+        </shape>
+    </scrollbar>
+
     <buttonlist name="basebuttonlist">
         <area>0,0,450,375</area>
         <layout>vertical</layout>
@@ -376,6 +408,21 @@
         </statetype>
     </buttonlist>
 
+    <!-- scrollbar and transparent item backgrounds -->
+    <buttonlist name="basebuttonlist3" from="basebuttonlist2">
+        <buttonarea>0,0,100%,100%</buttonarea>
+        <scrollbar name="scrollbar" from="basevertscrollbar">
+            <area>100%-10,0,10,100%</area>
+	</scrollbar>
+        <statetype name="buttonitem">
+            <state name="active">
+                <shape name="buttonbackground">
+                    <fill color="#666666" alpha="0" />
+                </shape>
+            </state>
+        </statetype>
+    </buttonlist>
+
     <!-- Base definition of a button -->
     <button name="basebutton">
         <position>0,0</position>
@@ -478,7 +525,7 @@
             <state name="selected">
                 <shape name="selected">
                   <area>0,0,45,45</area>
-                  <fill color="#ffffff" alpha="150" />  
+                  <fill color="#ffffff" alpha="150" />
                 </shape>
                 <imagetype name="background">
                     <position>12,12</position>
@@ -749,6 +796,9 @@
         <area>0,0,562,60</area>
         <layout>horizontal</layout>
         <buttonarea>0,0,532,60</buttonarea>
+        <scrollbar name="scrollbar" from="basehorizscrollbar">
+            <area>0,0,532,10</area>
+        </scrollbar>
         <statetype name="buttonitem">
             <state name="active">
                 <area>0,7,532,45</area>
@@ -1064,7 +1114,7 @@
         <!-- <shape name="background" from="basebackground"> -->
         <!--     <area>15,15,1890,1050</area> -->
         <!-- </shape> -->
-        
+
         <!-- <textarea name="title" from="basetextarea"> -->
         <!--     <area>30,22,1890,75</area> -->
         <!--     <font>baselarge</font> -->
@@ -1463,7 +1513,7 @@
         <shape name="backimg" from="basebackground">
             <area>0,0,870,247</area>
         </shape>
-        
+
         <textarea name="message" from="basetextarea">
             <area>15,12,840,75</area>
             <align>allcenter</align>
@@ -1485,7 +1535,7 @@
         </button>
 
     </window>
-       
+
     <window name="videowindow">
 
         <!-- Copy of MythBusyDialog without zoomin animation and -->
@@ -1680,7 +1730,7 @@
             <shape name="details_background" from="baseboxbackground">
                 <area>0,0,100%,100%</area>
             </shape>
-        
+
             <textarea name="title" from="basetextarea">
                 <area>10,10,1215,67</area>
                 <font>baselarge</font>

--- a/music-base.xml
+++ b/music-base.xml
@@ -175,7 +175,7 @@
     </statetype>
 
     <!-- current playlist button list -->
-    <buttonlist name="basecurrentplaylist" from="basebuttonlist2">
+    <buttonlist name="basecurrentplaylist" from="basebuttonlist3">
         <area>52,30,1815,510</area>
         <spacing>4</spacing>
         <layout>vertical</layout>
@@ -216,7 +216,7 @@
                             <position>7,7</position>
                             <filename>mm_stopicon.png</filename>
                         </imagetype>
-                    </state> 
+                    </state>
                 </statetype>
 
                 <statetype name="movestate" from="basemovingtracksstate">
@@ -492,6 +492,9 @@
 
     <buttonlist name="basetreebuttonlist" from="basebuttonlist">
         <searchposition>-1,430</searchposition>
+        <scrollbar name="scrollbar" from="basevertscrollbar">
+            <area>100%-10,0,10,100%</area>
+        </scrollbar>
     </buttonlist>
 
     <buttonlist name="basegallerybuttonlist">
@@ -500,12 +503,15 @@
         <spacing>10</spacing>
         <searchposition>-1,430</searchposition>
         <buttonarea>0,0,1837,570</buttonarea>
+        <scrollbar name="scrollbar" from="basevertscrollbar">
+            <area>100%-10,0,10,100%</area>
+        </scrollbar>
         <statetype name="buttonitem">
             <area>0,0,292,225</area>
             <state name="active">
                 <shape name="buttonbackground">
                     <area>0,0,292,225</area>
-                    <type>roundbox</type> 
+                    <type>roundbox</type>
                     <cornerradius>4</cornerradius>
                     <fill style="gradient">
                         <gradient start="#e8e262" end="#fe9735" alpha="50"/>
@@ -601,7 +607,7 @@
             <state name="selectedactive" from="active">
                 <shape name="buttonbackground">
                     <area>0,0,292,225</area>
-                    <type>roundbox</type> 
+                    <type>roundbox</type>
                     <cornerradius>4</cornerradius>
                     <fill style="gradient">
                         <gradient start="#e8e262" end="#fe9735" alpha="255" />
@@ -614,7 +620,7 @@
             <state name="selectedinactive" from="active">
                 <shape name="buttonbackground">
                     <area>0,0,292,225</area>
-                    <type>roundbox</type> 
+                    <type>roundbox</type>
                     <cornerradius>4</cornerradius>
                     <fill style="gradient">
                         <gradient start="#e8e262" end="#fe9735" alpha="150" />
@@ -848,7 +854,7 @@
             <fill color="#000000" alpha="50" />
         </shape>
 
-        <buttonlist name="currentplaylist" from="basebuttonlist2">
+        <buttonlist name="currentplaylist" from="basebuttonlist3">
             <area>45,22,1830,315</area>
             <spacing>0</spacing>
             <layout>vertical</layout>
@@ -903,7 +909,7 @@
                         <area>75,0,1635,69</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
-                        <template>%TITLE% by %ARTIST% on %ALBUM%</template>
+                        <template>%TITLE% \ %ARTIST% \ %ALBUM%</template>
                     </textarea>
 
                 </state>

--- a/music-base.xml
+++ b/music-base.xml
@@ -230,7 +230,7 @@
                 </textarea>
 
                 <textarea name="artist" from="buttontext">
-                    <area>1050,0,525,52</area>
+                    <area>1050,0,600,52</area>
                     <font>basesmall</font>
                     <align>left,vcenter</align>
                 </textarea>
@@ -259,35 +259,40 @@
                 </shape>
                 <textarea name="title" from="buttontext">
                     <area>225,0,780,52</area>
-                    <align>left,top</align>
+                    <align>left,vcenter</align>
                     <font>basesmall</font>
                 </textarea>
 
                 <textarea name="artist" from="buttontext">
-                    <area>1050,0,525,52</area>
+                    <area>1050,0,600,52</area>
                     <font>basesmall</font>
-                    <align>left,top</align>
+                    <align>left,vcenter</align>
                 </textarea>
                 <textarea name="tracknum" from="artist">
                     <area>135,0,75,52</area>
-                    <align>right,top</align>
+                    <align>right,vcenter</align>
                     <template>%1 -</template>
                 </textarea>
                 <textarea name="length" from="artist">
                     <area>1560,0,180,52</area>
-                    <align>right,top</align>
+                    <align>right,vcenter</align>
                     <font>basesmall</font>
                 </textarea>
 
                 <textarea name="album" from="buttontext">
                     <area>225,45,780,45</area>
                     <font>basesmall</font>
-                    <align>left,top</align>
+                    <align>left,vcenter</align>
                 </textarea>
                 <textarea name="genre" from="buttontext">
                     <area>1050,45,450,45</area>
                     <font>basesmall</font>
-                    <align>left,top</align>
+                    <align>left,vcenter</align>
+                </textarea>
+                <textarea name="year" from="buttontext">
+                    <area>1520,45,330,45</area>
+                    <font>basesmall</font>
+                    <align>left,vcenter</align>
                 </textarea>
 
                 <statetype name="ratingstate" from="baseratingstate">
@@ -298,8 +303,8 @@
                     <font>basesmall</font>
                 </textarea>
                 <textarea name="playcount" from="buttontext">
-                    <area>1410,90,330,45</area>
-                    <align>right,top</align>
+                    <area>1520,90,330,45</area>
+                    <align>left,vcenter</align>
                     <font>basesmall</font>
                     <template>Played %1 times</template>
                 </textarea>
@@ -314,14 +319,13 @@
                     <filename>mm_nothumb.png</filename>
                 </imagetype>
 
-
                 <textarea name="title" from="buttontext">
                     <area>225,0,780,52</area>
                     <align>left,top</align>
                     <font>basesmall</font>
                 </textarea>
                 <textarea name="artist" from="buttontext">
-                    <area>1050,0,525,52</area>
+                    <area>1050,0,600,52</area>
                     <font>basesmall</font>
                     <align>left,top</align>
                 </textarea>
@@ -673,8 +677,10 @@
 
     </group>
 
+    <!-- common bits now shared by music-ui and stream-ui -->
+
     <group name="baseinfopanel">
-        <area>0,600,1920,352</area>
+        <area>0,712,1920,352</area>
 
         <shape name="track_info_background" from="basebackground">
             <area>22,0,1875,352</area>
@@ -685,35 +691,45 @@
         </shape>
 
         <textarea name="title" from="basetextarea">
-            <area>345,7,1350,51</area>
+            <area>345,7,1300,51</area>
             <font>baselarge</font>
         </textarea>
 
         <textarea name="artist" from="basetextarea">
-            <area>345,67,1350,51</area>
+            <area>345,67,1255,51</area>
+            <font>basemedium</font>
+        </textarea>
+
+        <textarea name="year" from="basetextarea">
+            <area>1500,67,145,51</area>
             <font>basemedium</font>
         </textarea>
 
         <textarea name="album" from="basetextarea">
-            <area>345,120,1350,51</area>
+            <area>345,120,1300,51</area>
             <font>basemedium</font>
         </textarea>
 
-        <statetype name="ratingstate" from="baseratingstate">
-            <position>345,172</position>
-        </statetype>
+        <!-- ratingstate moved to music-ui, not stream-ui -->
 
         <textarea name="nexttitle" from="basetextarea">
             <font>basesmall</font>
-            <area>345,217,1260,52</area>
-            <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
+            <area>345,217,1300,52</area>
+            <template>Next: %NEXTTITLE% \ %NEXTARTIST% \ %NEXTALBUM%</template>
         </textarea>
 
-        <progressbar name="progress" from="basetrackprogress">
+        <progressbar name="progress" from="basetrackprogress" depends="!channel">
+            <position>345,307</position>
+        </progressbar>
+        <progressbar name="bufferprogress" from="basetrackprogress" depends="channel">
             <position>345,307</position>
         </progressbar>
 
-        <textarea name="time" from="basetextarea">
+        <textarea name="time" from="basetextarea" depends="!channel">
+            <area>345,262,262,52</area>
+            <font>basesmall</font>
+        </textarea>
+        <textarea name="bufferstatus" from="basetextarea" depends="channel">
             <area>345,262,262,52</area>
             <font>basesmall</font>
         </textarea>
@@ -751,9 +767,8 @@
             <area>52,19,234,232</area>
         </imagetype>
 
-        <group name="musiccontrols" from="basemusiccontrols">
-            <position>1027,277</position>
-        </group>
+        <!-- musiccontrols moved to music-ui and stream-ui -->
+
     </group>
 
     <group name="baseplayliststatusgroup">

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -119,11 +119,11 @@
             <align>vcenter,left</align>
             <value>Listen to Music</value>
         </textarea>
-        
+
         <shape name="clockbox" from="titlebox">
             <area>1200,15,690,90</area>
         </shape>
-        
+
         <clock name="clock">
             <area>1260,15,570,90</area>
             <font>baselarge</font>
@@ -131,7 +131,6 @@
             <template>%DATE%, %TIME%</template>
         </clock>
 
-        
         <shape name="playlist_background" from="basebackground">
             <area>22,120,1875,577</area>
             <type>roundbox</type>
@@ -192,7 +191,7 @@
             <align>vcenter,right</align>
             <template>%DATE%, %TIME%</template>
         </clock>
-        
+
         <shape name="playlist_background" from="basebackground">
             <area>22,120,1875,577</area>
             <type>roundbox</type>
@@ -201,11 +200,14 @@
 
         <buttonlist name="lyrics_list">
             <area>40,135,1840,550</area>
-            <buttonarea>0,0,115,550</buttonarea>
+            <buttonarea>0,0,100%-10,100%</buttonarea>
+            <scrollbar name="scrollbar" from="basevertscrollbar">
+                <area>100%-10,0,10,100%</area>
+            </scrollbar>
             <spacing>20</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
-            <showarrow>yes</showarrow>
+            <showarrow>no</showarrow>
             <searchposition>-1,410</searchposition>
             <statetype name="buttonitem">
                 <state name="active">
@@ -368,7 +370,7 @@
             <area>1605,52,225,45</area>
         </textarea>
 
-        <buttonlist name="tracks_list" from="basebuttonlist2">
+        <buttonlist name="tracks_list" from="basebuttonlist3">
             <area>45,132,1830,420</area>
             <spacing>0</spacing>
             <layout>vertical</layout>
@@ -398,7 +400,7 @@
                         <area>75,0,1635,69</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
-                        <template>%TITLE% by %ARTIST% on %ALBUM%</template>
+                        <template>%TITLE% \ %ARTIST% \ %ALBUM%</template>
                     </textarea>
 
                 </state>
@@ -623,7 +625,7 @@
             <area>60,510,1800,450</area>
         </shape>
 
-        <buttonlist name="tracks" from="basebuttonlist2">
+        <buttonlist name="tracks" from="basebuttonlist3">
             <area>90,540,1740,405</area>
             <buttonarea>0,0,1740,375</buttonarea>
             <spacing>0</spacing>
@@ -1495,6 +1497,9 @@
         <buttonlist name="coverartlist">
             <area>322,82,270,915</area>
             <buttonarea>0,0,255,832</buttonarea>
+            <scrollbar name="scrollbar" from="basevertscrollbar">
+                <area>100%-10,0,10,100%</area>
+            </scrollbar>
             <layout>grid</layout>
             <spacing>5</spacing>
             <statetype name="buttonitem">
@@ -1646,7 +1651,7 @@
             <value>Of The Following Conditions</value>
         </textarea>
 
-        <buttonlist name="criterialist" from="basebuttonlist2">
+        <buttonlist name="criterialist" from="basebuttonlist3">
             <area>300,405,1200,315</area>
             <spacing>0</spacing>
             <layout>vertical</layout>
@@ -1964,6 +1969,9 @@
             <arrange>stack</arrange>
             <showarrow>no</showarrow>
             <buttonarea>0,0,630,225</buttonarea>
+            <scrollbar name="scrollbar" from="basevertscrollbar">
+                <area>100%-10,0,10,100%</area>
+            </scrollbar>
             <statetype name="buttonitem">
                 <state name="active">
                     <area>0,0,630,69</area>
@@ -2141,7 +2149,7 @@
             <fill color="#000000" alpha="50" />
         </shape>
 
-        <buttonlist name="tracklist" from="basebuttonlist2">
+        <buttonlist name="tracklist" from="basebuttonlist3">
             <area>45,90,1830,975</area>
             <spacing>2</spacing>
             <layout>vertical</layout>
@@ -2161,7 +2169,7 @@
                         <area>75,0,1560,69</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
-                        <template>%TITLE% by %ARTIST% on %ALBUM%</template>
+                        <template>%TITLE% \ %ARTIST% \ %ALBUM%</template>
                     </textarea>
 
                     <textarea name="length">

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -282,7 +282,7 @@
         </textarea>
 
         <buttontree name="playlist_tree">
-            <area>45,90,1830,465</area>
+            <area>45,90,1830,470</area>
             <numlists>3</numlists>
             <spacing>10</spacing>
             <buttonlist name="listtemplate" from="basetreebuttonlist" />

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -120,12 +120,8 @@
             <value>Listen to Music</value>
         </textarea>
         
-        <shape name="clockbox">
+        <shape name="clockbox" from="titlebox">
             <area>1200,15,690,90</area>
-            <type>roundbox</type>
-            <fill color="#000000" alpha="150" />
-            <line color="#FFFFFF" alpha="0" width="0" />
-            <cornerradius>45</cornerradius>
         </shape>
         
         <clock name="clock">
@@ -165,7 +161,12 @@
         </group>
 
         <group name="infopanel" from="baseinfopanel">
-            <area>0,712,1875,352</area>
+            <statetype name="ratingstate" from="baseratingstate">
+                <position>345,190</position>
+            </statetype>
+            <group name="musiccontrols" from="basemusiccontrols">
+                <position>1027,277</position>
+            </group>
         </group>
 
         <!-- <imagetype name="animation"> -->
@@ -247,7 +248,12 @@
         </textarea>
 
         <group name="trackinfopanel" from="baseinfopanel">
-            <area>0,712,1875,352</area>
+            <statetype name="ratingstate" from="baseratingstate">
+                <position>345,190</position>
+            </statetype>
+            <group name="musiccontrols" from="basemusiccontrols">
+                <position>1027,277</position>
+            </group>
         </group>
 
     </window>
@@ -448,10 +454,10 @@
 
     <!-- used in the visualiser screen to show some track details after a track change -->
     <window name="trackinfo_popup">
-        <area>-1,750,1500,285</area>
+        <area>-1,750,1300,285</area>
 
         <shape name="background" from="basebackground">
-            <area>0,0,1500,285</area>
+            <area>0,0,1300,285</area>
             <type>roundbox</type>
         <fill color="#000000" alpha="150" />
         <line color="#222222" alpha="150" width="2" />
@@ -464,33 +470,40 @@
         </imagetype>
 
         <textarea name="title" from="basetextarea">
-            <area>270,22,622,51</area>
+            <area>270,22,1030,51</area>
             <font>baselarge</font>
         </textarea>
 
         <textarea name="artist" from="basetextarea">
-            <area>270,75,622,52</area>
+            <area>270,75,900,51</area>
             <font>basemedium</font>
+        </textarea>
+        <textarea name="year" from="basetextarea">
+          <area>1170,75,130,51</area>
+          <font>basemedium</font>
         </textarea>
 
         <textarea name="album" from="basetextarea">
-            <area>270,120,622,52</area>
+            <area>270,128,900,51</area>
             <font>basemedium</font>
         </textarea>
 
-        <statetype name="ratingstate" from="baseratingstate">
-            <position>270,172</position>
-        </statetype>
-
-<!--
-        <textarea name="length" from="basetextarea">
-            <area>255,187,277,37</area>
-        </textarea>
--->
         <textarea name="nexttitle" from="basetextarea">
-            <area>270,217,1200,37</area>
-            <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
+            <area>270,217,1030,37</area>
+            <template>Next: %NEXTTITLE% \ %NEXTARTIST% \ %NEXTALBUM%</template>
         </textarea>
+        <textarea name="url" from="basetextarea" depends="!nexttitle">
+            <area>270,217,1030,37</area>
+        </textarea>
+
+        <textarea name="length" from="basetextarea" depends="nexttitle">
+            <area>1170,128,130,51</area>
+            <font>basemedium</font>
+        </textarea>
+
+        <statetype name="ratingstate" from="baseratingstate" depends="nexttitle">
+            <position>270,187</position>
+        </statetype>
 
         <imagetype name="coverart">
             <filename>mm_nothumb.png</filename>

--- a/stream-ui.xml
+++ b/stream-ui.xml
@@ -28,21 +28,15 @@
             <value>Press MENU to add some radio streams to play.</value>
         </textarea>
 
-        <buttonlist name="streamlist" from="basebuttonlist2">
+        <buttonlist name="streamlist" from="basebuttonlist3">
             <area>37,37,1837,369</area>
             <spacing>5</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
-            <showarrow>no</showarrow>
-            <buttonarea>0,0,1837,345</buttonarea>
+            <buttonarea>0,0,100%-10,100%</buttonarea>
             <statetype name="buttonitem">
                 <state name="active">
                     <area>0,0,100%,52</area>
-                    <shape name="buttonbackground">
-                      <type>roundbox</type>
-                      <area>0,0,100%,95%</area>
-                      <fill color="#333333" alpha="0" />
-                    </shape>
                     <imagetype name="buttonimage">
                         <area>25,0,52,52</area>
                         <filename>mm_icecast.png</filename>
@@ -111,21 +105,16 @@
             </statetype>
         </buttonlist>
 
-        <buttonlist name="playedtrackslist" from="basebuttonlist2">
+        <buttonlist name="playedtrackslist" from="basebuttonlist3">
             <area>37,447,1837,233</area>
             <spacing>5</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
             <showarrow>no</showarrow>
-            <buttonarea>0,0,1837,225</buttonarea>
+            <buttonarea>0,0,100%-10,100%</buttonarea>
             <statetype name="buttonitem">
                 <state name="active">
                     <area>0,0,100%,52</area>
-                    <shape name="buttonbackground">
-                      <type>roundbox</type>
-                      <area>0,0,100%,95%</area>
-                      <fill color="#333333" alpha="0" />
-                    </shape>
                     <imagetype name="buttonimage">
                         <area>25,0,52,52</area>
                         <filename>mm_icecast.png</filename>
@@ -186,7 +175,7 @@
         <textarea name="album" from="basetextarea">
             <template></template>
         </textarea>
-      
+
        <textarea name="channel" from="basetextarea">
             <area>345,127,1300,51</area>
             <font>basemedium</font>
@@ -408,22 +397,17 @@
             <value></value>
         </textarea>
 
-        <buttonlist name="streamlist" from="basebuttonlist2">
+        <buttonlist name="streamlist" from="basebuttonlist3">
             <area>45,322,1830,750</area>
             <spacing>0</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
             <showarrow>no</showarrow>
             <searchposition>-1,50</searchposition>
-            <buttonarea>0,0,1830,750</buttonarea>
+            <buttonarea>0,0,100%-10,100%</buttonarea>
             <statetype name="buttonitem">
                 <state name="active">
                     <area>0,0,100%,54</area>
-                    <shape name="buttonbackground">
-                      <type>roundbox</type>
-                      <area>0,0,100%,95%</area>
-                      <fill color="#333333" alpha="0" />
-                    </shape>
                     <imagetype name="buttonimage">
                         <area>55,0,52,52</area>
                         <filename>mm_icecast.png</filename>

--- a/stream-ui.xml
+++ b/stream-ui.xml
@@ -1,537 +1,440 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE mythuitheme SYSTEM "http://www.mythtv.org/schema/mythuitheme.dtd">
-	<!-- patched -->
 
 <mythuitheme>
 
-	<window name="streamview"  include="music-base.xml">
-
-		<shape name="streamlist_background" from="basebackground">
-			<area>22,22,1875,397</area>
-		</shape>
-
-		<shape name="playlist_background" from="basebackground">
-			<area>22,435,1875,255</area>
-		</shape>
-
-		<shape name="track_info_background" from="basebackground">
-			<area>22,705,1875,345</area>
-		</shape>
-
-		<textarea name="nostreams" from="basetextarea">
-			<area>37,37,1837,375</area>
-			<multiline>yes</multiline>
-			<align>allcenter</align>
-			<value>Press MENU to add some radio streams to play.</value>
-		</textarea>
-
-		<buttonlist name="streamlist" from="basebuttonlist2">
-			<area>37,37,1837,375</area>
-			<spacing>0</spacing>
-			<layout>vertical</layout>
-			<arrange>stack</arrange>
-			<showarrow>no</showarrow>
-			<buttonarea>0,0,1225,230</buttonarea>
-			<statetype name="buttonitem">
-				<state name="active">
-					<area>0,0,100%,69</area>
-
-					<imagetype name="buttonimage">
-						<area>7,7,54,54</area>
-						<filename>mm_icecast.png</filename>
-					</imagetype>
-
-					<statetype name="playstate">
-						<position>1785,15</position>
-						<state name="playing">
-							<imagetype name="animation">
-								<position>0,0</position>
-								<filepattern low="1" high="8">mm_playing_%1.png</filepattern>
-								<delay>160</delay>
-							</imagetype>
-						</state>
-						<state name="paused">
-							<imagetype name="animation">
-								<position>7,7</position>
-								<filename>mm_pauseicon.png</filename>
-							</imagetype>
-						</state>
-						<state name="stopped">
-							<imagetype name="animation">
-								<position>7,7</position>
-								<filename>mm_stopicon.png</filename>
-							</imagetype>
-						</state>
-					</statetype>
-
-					<textarea name="station" from="buttontext">
-						<area>105,0,525,69</area>
-						<align>left,vcenter</align>
-						<font>basesmall</font>
-					</textarea>
-					<textarea name="channel" from="buttontext">
-						<area>645,0,555,69</area>
-						<font>basesmall</font>
-						<align>left,vcenter</align>
-					</textarea>
-					<textarea name="genre" from="channel">
-						<area>1215,0,555,69</area>
-						<align>left,vcenter</align>
-						<font>basesmall</font>
-					</textarea>
-
-				</state>
-				<state name="selectedactive" from="active">
-					<imagetype name="buttonimage">
-						<area>7,7,54,54</area>
-						<filename>mm_icecast.png</filename>
-					</imagetype>
-					<shape name="selectbar">
-						<area>0,0,100%,69</area>
-					</shape>
-				</state>
-				<state name="selectedinactive" from="active">
-					<shape name="selectbar">
-						<area>0,0,100%,69</area>
-					</shape>
-				</state>
-			</statetype>
-			<statetype name="upscrollarrow">
-				<position>1710,345</position>
-			</statetype>
-			<statetype name="downscrollarrow">
-				<position>1770,345</position>
-			</statetype>
-		</buttonlist>
-
-		<buttonlist name="playedtrackslist" from="basebuttonlist2">
-			<area>37,450,1837,225</area>
-			<spacing>0</spacing>
-			<layout>vertical</layout>
-			<arrange>stack</arrange>
-			<showarrow>no</showarrow>
-			<buttonarea>0,0,1225,150</buttonarea>
-			<statetype name="buttonitem">
-				<state name="active">
-					<area>0,0,100%,69</area>
-
-					<imagetype name="buttonimage">
-						<area>7,7,54,54</area>
-						<filename>mm_icecast.png</filename>
-					</imagetype>
-
-					<textarea name="tracknum" from="buttontext">
-						<area>75,0,75,69</area>
-						<align>right,vcenter</align>
-						<template>%1 -</template>
-					</textarea>
-
-					<textarea name="title" from="buttontext">
-						<area>165,0,675,69</area>
-						<align>left,vcenter</align>
-						<font>basesmall</font>
-					</textarea>
-
-					<textarea name="artist" from="buttontext">
-						<area>855,0,720,69</area>
-						<font>basesmall</font>
-						<align>left,vcenter</align>
-					</textarea>
-
-					<textarea name="length" from="artist">
-						<area>1590,0,180,69</area>
-						<align>right,vcenter</align>
-						<font>basesmall</font>
-					</textarea>
-
-				</state>
-				<state name="selectedactive" from="active">
-					<imagetype name="buttonimage">
-						<area>7,7,54,54</area>
-						<filename>mm_icecast.png</filename>
-					</imagetype>
-					<shape name="selectbar">
-						<area>0,0,100%,69</area>
-					</shape>
-				</state>
-				<state name="selectedinactive" from="active">
-					<shape name="selectbar">
-						<area>0,0,100%,69</area>
-					</shape>
-				</state>
-			</statetype>
-			<statetype name="upscrollarrow">
-				<position>1710,202</position>
-			</statetype>
-			<statetype name="downscrollarrow">
-				<position>1770,202</position>
-			</statetype>
-		</buttonlist>
-
-		<imagetype name="mm_blackhole_border">
-			<filename>mm_blackhole_border.png</filename>
-			<area>48,733,243,243</area>
-		</imagetype>
-
-		<textarea name="title" from="basetextarea">
-			<area>345,727,1350,51</area>
-			<font>baselarge</font>
-		</textarea>
-
-		<textarea name="artist" from="basetextarea">
-			<area>345,787,1350,51</area>
-			<font>basemedium</font>
-		</textarea>
-
-		<textarea name="channel" from="basetextarea">
-			<area>345,840,1350,51</area>
-			<font>basemedium</font>
-			<template>%STATION% - %CHANNEL%</template>
-		</textarea>
-
-		<textarea name="url" from="basetextarea">
-			<font>basesmall</font>
-			<area>345,892,1260,52</area>
-		</textarea>
-
-		<progressbar name="bufferprogress">
-			<position>345,1005</position>
-			<layout>horizontal</layout>
-		   <style>reveal</style>
-			<imagetype name="background">
-				<filename>mm_progress-bg.png</filename>
-			</imagetype>
-			<imagetype name="progressimage">
-				<filename>mm_progress-fg.png</filename>
-			</imagetype>
-		</progressbar>
-
-		<textarea name="bufferstatus" from="basetextarea">
-			<area>345,967,600,52</area>
-			<font>basesmall</font>
-			<value></value>
-		</textarea>
-
-		<imagetype name="visualizer_border">
-			<filename>mm_blackhole_border.png</filename>
-			<area>1623,733,243,243</area>
-		</imagetype>
-
-		<video name="visualizer">
-			<area>1627,739,234,232</area>
-		</video>
-
-		<textarea name="visualizername" from="basetextarea">
-			<area>1627,975,234,52</area>
-			<font>basesmall</font>
-			<align>center</align>
-		</textarea>
-
-		<textarea name="volume" from="basevolume">
-			<position>105,1000</position>
-		</textarea>
-
-		<statetype name="mutestate" from="basemutestate">
-			<position>45,1005</position>
-		</statetype>
-
-		<imagetype name="coverart">
-			<filename>mm_nothumb.png</filename>
-			<area>52,739,234,232</area>
-		</imagetype>
-
-		<button name="play" from="baseplaybutton">
-			<position>1260,975</position>
-		</button>
-
-		<button name="stop" from="basestopbutton">
-			<position>1327,975</position>
-		</button>
-
-	</window>
-
-	<window name="editstreammetadata">
-
-		<textarea name="title" from="basetextarea">
-			<area>50,5,1837,50</area>
-			<font>baselarge</font>
-			<value>Add/Edit Music Stream</value>
-		</textarea>
-
-		<textarea name="broadcasterlabel" >
-			<area>20,103,350,50</area>
-			<font>basemedium</font>
-			<align>right,vcenter</align>
-			<value>Station:</value>
-		</textarea>
-		<textedit name="broadcasteredit" from="basetextedit">
-			<position>410,103</position>
-		</textedit>
-
-		<button name="searchbutton" from="basewidebutton">
-			<position>1200,98</position>
-			<value>Search for Stream</value>
-		</button>
-
-		<textarea name="channellabel" from="broadcasterlabel">
-			<position>20,165</position>
-			<value>Channel:</value>
-		</textarea>
-		<textedit name="channeledit" from="broadcasteredit">
-			<position>410,165</position>
-		</textedit>
-
-		<textarea name="descriptionlabel" from="broadcasterlabel">
-			<position>20,225</position>
-			<value>Description:</value>
-		</textarea>
-		<textedit name="descriptionedit" from="broadcasteredit">
-			<area>410,225,970,50</area>
-		</textedit>
-
-		<textarea name="urllabel" from="broadcasterlabel">
-			<position>20,285</position>
-			<value>URL 1:</value>
-		</textarea>
-		<textedit name="url1edit" from="descriptionedit">
-			<position>410,285</position>
-		</textedit>
-
-		<textarea name="url2label" from="broadcasterlabel">
-			<position>20,345</position>
-			<value>URL 2:</value>
-		</textarea>
-		<textedit name="url2edit" from="descriptionedit">
-			<position>410,345</position>
-		</textedit>
-
-		<textarea name="url3label" from="broadcasterlabel">
-			<position>20,405</position>
-			<value>URL 3:</value>
-		</textarea>
-		<textedit name="url3edit" from="descriptionedit">
-			<position>410,405</position>
-		</textedit>
-
-		<textarea name="url4label" from="broadcasterlabel">
-			<position>20,465</position>
-			<value>URL 4:</value>
-		</textarea>
-		<textedit name="url4edit" from="descriptionedit">
-			<position>410,465</position>
-		</textedit>
-
-		<textarea name="url5label" from="broadcasterlabel">
-			<position>20,525</position>
-			<value>URL 5:</value>
-		</textarea>
-		<textedit name="url5edit" from="descriptionedit">
-			<position>410,525</position>
-		</textedit>
-
-		<textarea name="logourllabel" from="broadcasterlabel">
-			<position>20,585</position>
-			<value>Logo URL:</value>
-		</textarea>
-		<textedit name="logourledit" from="descriptionedit">
-			<position>410,585</position>
-		</textedit>
-
-		<textarea name="countrylabel" from="broadcasterlabel">
-			<position>860,585</position>
-			<value>Country:</value>
-		</textarea>
-		<textedit name="countryedit" from="broadcasteredit">
-			<area>1250,585,320,50</area>
-		</textedit>
-
-		<textarea name="genrelabel" from="broadcasterlabel">
-			<position>20,645</position>
-			<value>Genres:</value>
-		</textarea>
-		<textedit name="genreedit" from="broadcasteredit">
-			<position>410,645</position>
-		</textedit>
-
-		<textarea name="languagelabel" from="broadcasterlabel">
-			<position>860,645</position>
-			<value>Language:</value>
-		</textarea>
-		<textedit name="languageedit" from="countryedit">
-			<position>1250,645</position>
-		</textedit>
-
-		<textarea name="formatlabel" from="broadcasterlabel">
-			<position>20,705</position>
-			<value>Metadata Format:</value>
-		</textarea>
-		<textedit name="formatedit" from="broadcasteredit">
-			<position>410,705</position>
-		</textedit>
-
-		<button name="cancelbutton" from="basebutton">
-			<position>200,960</position>
-			<value>Cancel</value>
-		</button>
-
-		<button name="savebutton" from="basebutton">
-			<position>1200,960</position>
-			<value>Save</value>
-		</button>
-
-	</window>
-
-	<window name="searchstream">
-
-		<textarea name="title" from="basetextarea">
-			<area>22,7,1200,75</area>
-			<font>baselarge</font>
-			<value>Search for Music Stream</value>
-		</textarea>
-
-		<textarea name="broadcasterlabel" >
-			<area>4,80,310,50</area>
-			<font>basemedium</font>
-			<align>right,vcenter</align>
-			<value>Station:</value>
-		</textarea>
-		<buttonlist name="broadcasterlist" from="basemediumselector">
-			<position>330,81</position>
-		</buttonlist>
-
-		<textarea name="countrylabel" >
-			<area>850,80,310,50</area>
-			<font>basemedium</font>
-			<align>right,vcenter</align>
-			<value>Country:</value>
-		</textarea>
-		<buttonlist name="countrylist" from="basemediumselector">
-			<position>1200,81</position>
-		</buttonlist>
-
-		<textarea name="genrelabel" from="broadcasterlabel">
-			<position>4,162</position>
-			<value>Genre:</value>
-		</textarea>
-		<buttonlist name="genrelist" from="basemediumselector">
-			<position>330,163</position>
-		</buttonlist>
-
-		<textarea name="languagelabel" >
-			<area>850,162,310,50</area>
-			<font>basemedium</font>
-			<align>right,vcenter</align>
-			<value>Language:</value>
-		</textarea>
-		<buttonlist name="languagelist" from="basemediumselector">
-			<position>1200,163</position>
-		</buttonlist>
-
-		<textarea name="channellabel" from="broadcasterlabel">
-			<position>4,249</position>
-			<value>Channel:</value>
-		</textarea>
-		<textedit name="channeledit" from="basetextedit">
-			<position>330,250</position>
-		</textedit>
-
-		<textarea name="matcheslable" from="broadcasterlabel">
-			<area>850,249,280,50</area>
-			<align>right,vcenter</align>
-			<value>Matches:</value>
-		</textarea>
-		<textarea name="matchestext" from="broadcasterlabel">
-			<area>1200,250,350,50</area>
-			<align>left,vcenter</align>
-			<value></value>
-		</textarea>
-
-		<buttonlist name="streamlist" from="basebuttonlist2">
-			<area>45,337,1830,1020</area>
-			<spacing>0</spacing>
-			<layout>vertical</layout>
-			<arrange>stack</arrange>
-			<showarrow>no</showarrow>
-			<searchposition>-1,50</searchposition>
-			<buttonarea>0,0,1220,680</buttonarea>
-			<statetype name="buttonitem">
-				<state name="active">
-					<area>0,0,100%,54</area>
-
-					<imagetype name="buttonimage">
-						<area>7,7,54,54</area>
-						<filename>mm_icecast.png</filename>
-					</imagetype>
-
-					<statetype name="selectedstate">
-						<position>1777,15</position>
-						<state name="off"></state>
-						<state name="on">
-							<imagetype name="statusimage">
-								<filename>playlist_yes.png</filename>
-							</imagetype>
-						</state>
-					</statetype>
-
-					<textarea name="broadcasterchannel" from="buttontext">
-						<area>75,0,1080,46</area>
-						<align>left,vcenter</align>
-						<font>basesmall</font>
-					 </textarea>
-
-					<textarea name="genre" from="buttontext">
-						<area>1000,0,725,46</area>
-						<align>left,vcenter</align>
-						<font>basesmall</font>
-					</textarea>
-
-					<textarea name="language" from="buttontext">
-						<area>1580,0,180,46</area>
-						<align>left,vcenter</align>
-						<font>basesmall</font>
-					</textarea>
-				</state>
-
-				<state name="selectedactive" from="active">
-					<imagetype name="buttonimage">
-						<area>7,7,54,54</area>
-						<filename>mm_icecast.png</filename>
-					</imagetype>
-					<shape name="selectbar">
-						<area>0,0,1830,54</area>
-					</shape>
-				</state>
-				<state name="selectedinactive" from="active">
-					<shape name="selectbar">
-						<area>0,0,1830,54</area>
-					</shape>
-				</state>
-
-				<state name="selectedactive" from="active">
-					<imagetype name="buttonimage">
-						<area>7,7,54,54</area>
-						<filename>mm_icecast.png</filename>
-					</imagetype>
-					<shape name="selectbar">
-						<area>0,0,1830,54</area>
-					</shape>
-				</state>
-				<state name="selectedinactive" from="active">
-					<shape name="selectbar">
-						<area>0,0,1830,54</area>
-					</shape>
-				</state>
-			</statetype>
-
-			<statetype name="upscrollarrow">
-				<position>1740,697</position>
-			</statetype>
-
-			<statetype name="downscrollarrow">
-				<position>1785,697</position>
-			</statetype>
-		</buttonlist>
-
-	</window>
+    <window name="streamview"  include="music-base.xml">
+
+        <shape name="streamlist_background" from="basebackground">
+            <area>22,22,1875,397</area>
+        </shape>
+
+        <shape name="playlist_background" from="basebackground">
+            <area>22,435,1875,255</area>
+        </shape>
+
+        <shape name="track_info_background" from="basebackground">
+            <area>22,705,1875,345</area>
+        </shape>
+
+        <textarea name="nostreams" from="basetextarea">
+            <area>37,37,1837,375</area>
+            <multiline>yes</multiline>
+            <align>allcenter</align>
+            <value>Press MENU to add some radio streams to play.</value>
+        </textarea>
+
+        <buttonlist name="streamlist" from="basebuttonlist2">
+            <area>37,37,1837,375</area>
+            <spacing>0</spacing>
+            <layout>vertical</layout>
+            <arrange>stack</arrange>
+            <showarrow>no</showarrow>
+            <buttonarea>0,0,1225,230</buttonarea>
+            <statetype name="buttonitem">
+                <state name="active">
+                    <area>0,0,100%,69</area>
+
+                    <imagetype name="buttonimage">
+                        <area>7,7,54,54</area>
+                        <filename>mm_icecast.png</filename>
+                    </imagetype>
+
+                    <statetype name="playstate">
+                        <position>1785,15</position>
+                        <state name="playing">
+                            <imagetype name="animation">
+                                <position>0,0</position>
+                                <filepattern low="1" high="8">mm_playing_%1.png</filepattern>
+                                <delay>160</delay>
+                            </imagetype>
+                        </state>
+                        <state name="paused">
+                            <imagetype name="animation">
+                                <position>7,7</position>
+                                <filename>mm_pauseicon.png</filename>
+                            </imagetype>
+                        </state>
+                        <state name="stopped">
+                            <imagetype name="animation">
+                                <position>7,7</position>
+                                <filename>mm_stopicon.png</filename>
+                            </imagetype>
+                        </state>
+                    </statetype>
+
+                    <textarea name="station" from="buttontext">
+                        <area>105,0,525,69</area>
+                        <align>left,vcenter</align>
+                        <font>basesmall</font>
+                    </textarea>
+                    <textarea name="channel" from="buttontext">
+                        <area>645,0,555,69</area>
+                        <font>basesmall</font>
+                        <align>left,vcenter</align>
+                    </textarea>
+                    <textarea name="genre" from="channel">
+                        <area>1215,0,555,69</area>
+                        <align>left,vcenter</align>
+                        <font>basesmall</font>
+                    </textarea>
+
+                </state>
+                <state name="selectedactive" from="active">
+                    <imagetype name="buttonimage">
+                        <area>7,7,54,54</area>
+                        <filename>mm_icecast.png</filename>
+                    </imagetype>
+                    <shape name="selectbar">
+                        <area>0,0,100%,69</area>
+                    </shape>
+                </state>
+                <state name="selectedinactive" from="active">
+                    <shape name="selectbar">
+                        <area>0,0,100%,69</area>
+                    </shape>
+                </state>
+            </statetype>
+            <statetype name="upscrollarrow">
+                <position>1710,345</position>
+            </statetype>
+            <statetype name="downscrollarrow">
+                <position>1770,345</position>
+            </statetype>
+        </buttonlist>
+
+        <buttonlist name="playedtrackslist" from="basebuttonlist2">
+            <area>37,450,1837,225</area>
+            <spacing>0</spacing>
+            <layout>vertical</layout>
+            <arrange>stack</arrange>
+            <showarrow>no</showarrow>
+            <buttonarea>0,0,1225,150</buttonarea>
+            <statetype name="buttonitem">
+                <state name="active">
+                    <area>0,0,100%,69</area>
+
+                    <imagetype name="buttonimage">
+                        <area>7,7,54,54</area>
+                        <filename>mm_icecast.png</filename>
+                    </imagetype>
+
+                    <textarea name="tracknum" from="buttontext">
+                        <area>75,0,75,69</area>
+                        <align>right,vcenter</align>
+                        <template>%1 -</template>
+                    </textarea>
+
+                    <textarea name="title" from="buttontext">
+                        <area>165,0,675,69</area>
+                        <align>left,vcenter</align>
+                        <font>basesmall</font>
+                    </textarea>
+
+                    <textarea name="artist" from="buttontext">
+                        <area>855,0,720,69</area>
+                        <font>basesmall</font>
+                        <align>left,vcenter</align>
+                    </textarea>
+
+                    <textarea name="length" from="artist">
+                        <area>1590,0,180,69</area>
+                        <align>right,vcenter</align>
+                        <font>basesmall</font>
+                    </textarea>
+
+                </state>
+                <state name="selectedactive" from="active">
+                    <imagetype name="buttonimage">
+                        <area>7,7,54,54</area>
+                        <filename>mm_icecast.png</filename>
+                    </imagetype>
+                    <shape name="selectbar">
+                        <area>0,0,100%,69</area>
+                    </shape>
+                </state>
+                <state name="selectedinactive" from="active">
+                    <shape name="selectbar">
+                        <area>0,0,100%,69</area>
+                    </shape>
+                </state>
+            </statetype>
+            <statetype name="upscrollarrow">
+                <position>1710,202</position>
+            </statetype>
+            <statetype name="downscrollarrow">
+                <position>1770,202</position>
+            </statetype>
+        </buttonlist>
+
+        <imagetype name="mm_blackhole_border">
+            <filename>mm_blackhole_border.png</filename>
+            <area>48,733,243,243</area>
+        </imagetype>
+
+        <textarea name="title" from="basetextarea">
+            <area>345,727,1350,51</area>
+            <font>baselarge</font>
+        </textarea>
+
+        <textarea name="artist" from="basetextarea">
+            <area>345,787,1350,51</area>
+            <font>basemedium</font>
+        </textarea>
+
+        <textarea name="channel" from="basetextarea">
+            <area>345,840,1350,51</area>
+            <font>basemedium</font>
+            <template>%STATION% - %CHANNEL%</template>
+        </textarea>
+
+        <textarea name="url" from="basetextarea">
+            <font>basesmall</font>
+            <area>345,892,1260,52</area>
+        </textarea>
+
+        <progressbar name="bufferprogress">
+            <position>345,1005</position>
+            <layout>horizontal</layout>
+           <style>reveal</style>
+            <imagetype name="background">
+                <filename>mm_progress-bg.png</filename>
+            </imagetype>
+            <imagetype name="progressimage">
+                <filename>mm_progress-fg.png</filename>
+            </imagetype>
+        </progressbar>
+
+        <textarea name="bufferstatus" from="basetextarea">
+            <area>345,967,600,52</area>
+            <font>basesmall</font>
+            <value></value>
+        </textarea>
+
+        <imagetype name="visualizer_border">
+            <filename>mm_blackhole_border.png</filename>
+            <area>1623,733,243,243</area>
+        </imagetype>
+
+        <video name="visualizer">
+            <area>1627,739,234,232</area>
+        </video>
+
+        <textarea name="visualizername" from="basetextarea">
+            <area>1627,975,234,52</area>
+            <font>basesmall</font>
+            <align>center</align>
+        </textarea>
+
+        <textarea name="volume" from="basevolume">
+            <position>105,1000</position>
+        </textarea>
+
+        <statetype name="mutestate" from="basemutestate">
+            <position>45,1005</position>
+        </statetype>
+
+        <imagetype name="coverart">
+            <filename>mm_nothumb.png</filename>
+            <area>52,739,234,232</area>
+        </imagetype>
+
+        <button name="play" from="baseplaybutton">
+            <position>1260,975</position>
+        </button>
+
+        <button name="stop" from="basestopbutton">
+            <position>1327,975</position>
+        </button>
+
+    </window>
+
+    <window name="editstreammetadata">
+
+        <textarea name="title" from="basetextarea">
+            <area>22,7,1200,75</area>
+            <font>baselarge</font>
+            <value>Add/Edit Music Stream</value>
+        </textarea>
+
+        <textarea name="stationlabel" >
+            <area>246,159,375,75</area>
+            <font>basemedium</font>
+            <align>right,vcenter</align>
+            <value>Station:</value>
+        </textarea>
+        <textedit name="stationedit" from="basetextedit">
+            <position>636,159</position>
+        </textedit>
+
+        <button name="searchbutton" from="basewidebutton">
+            <position>1260,162</position>
+            <value>Search for Stream</value>
+        </button>
+
+        <textarea name="channellabel" from="stationlabel">
+            <position>246,249</position>
+            <value>Channel:</value>
+        </textarea>
+        <textedit name="channeledit" from="stationedit">
+            <position>636,249</position>
+        </textedit>
+
+        <textarea name="urllabel" from="stationlabel">
+            <position>246,339</position>
+            <value>URL:</value>
+        </textarea>
+        <textedit name="urledit" from="stationedit">
+            <area>636,339,1050,75</area>
+        </textedit>
+
+        <textarea name="logourllabel" from="stationlabel">
+            <position>246,429</position>
+            <value>Logo URL:</value>
+        </textarea>
+        <textedit name="logourledit" from="urledit">
+            <position>636,429</position>
+        </textedit>
+
+        <textarea name="genrelabel" from="stationlabel">
+            <position>246,519</position>
+            <value>Genres:</value>
+        </textarea>
+        <textedit name="genreedit" from="urledit">
+            <position>636,519</position>
+        </textedit>
+
+        <textarea name="formatlabel" from="stationlabel">
+            <position>246,609</position>
+            <value>Metadata Format:</value>
+        </textarea>
+        <textedit name="formatedit" from="stationedit">
+            <position>636,609</position>
+        </textedit>
+
+        <button name="cancelbutton" from="basebutton">
+            <position>150,975</position>
+            <value>Cancel</value>
+        </button>
+
+        <button name="savebutton" from="basebutton">
+            <position>1500,975</position>
+            <value>Save</value>
+        </button>
+
+    </window>
+
+    <window name="searchstream">
+
+        <textarea name="title" from="basetextarea">
+            <area>22,7,1200,75</area>
+            <font>baselarge</font>
+            <value>Search for Music Stream</value>
+        </textarea>
+
+        <textarea name="stationlabel" >
+            <area>246,79,375,75</area>
+            <font>basemedium</font>
+            <align>right,vcenter</align>
+            <value>Station:</value>
+        </textarea>
+        <buttonlist name="stationlist" from="basemediumselector">
+            <position>630,84</position>
+        </buttonlist>
+
+        <textarea name="genrelabel" from="stationlabel">
+            <position>246,162</position>
+            <value>Genre:</value>
+        </textarea>
+        <buttonlist name="genrelist" from="basemediumselector">
+            <position>630,166</position>
+        </buttonlist>
+
+        <textarea name="channellabel" from="stationlabel">
+            <position>246,249</position>
+            <value>Channel:</value>
+        </textarea>
+        <textedit name="channeledit" from="basetextedit">
+            <position>630,249</position>
+        </textedit>
+
+        <textarea name="matcheslable" from="stationlabel">
+            <area>1230,249,225,75</area>
+            <align>right,vcenter</align>
+            <value>Matches:</value>
+        </textarea>
+
+        <textarea name="matchestext" from="stationlabel">
+            <area>1485,249,225,75</area>
+            <align>left,vcenter</align>
+        </textarea>
+
+        <buttonlist name="streamlist" from="basebuttonlist2">
+            <area>45,337,1830,720</area>
+            <spacing>0</spacing>
+            <layout>vertical</layout>
+            <arrange>stack</arrange>
+            <showarrow>no</showarrow>
+            <searchposition>-1,50</searchposition>
+            <buttonarea>0,0,1220,480</buttonarea>
+            <statetype name="buttonitem">
+                <state name="active">
+                    <area>0,0,100%,69</area>
+                    <imagetype name="buttonimage">
+                        <area>7,7,54,54</area>
+                        <filename>mm_icecast.png</filename>
+                    </imagetype>
+
+                    <statetype name="selectedstate">
+                        <position>1777,15</position>
+                        <state name="off"></state>
+                        <state name="on">
+                            <imagetype name="statusimage">
+                                <filename>playlist_yes.png</filename>
+                            </imagetype>
+                        </state>
+                    </statetype>
+
+                    <textarea name="station" from="buttontext">
+                        <area>75,0,900,69</area>
+                        <align>left,vcenter</align>
+                        <font>basesmall</font>
+                        <template>%STATION% - %Channel%</template>
+                    </textarea>
+
+                    <textarea name="genre" from="buttontext">
+                        <area>990,0,825,69</area>
+                        <align>left,vcenter</align>
+                        <font>basesmall</font>
+                    </textarea>
+
+                </state>
+                <state name="selectedactive" from="active">
+                    <imagetype name="buttonimage">
+                        <area>7,7,54,54</area>
+                        <filename>mm_icecast.png</filename>
+                    </imagetype>
+                    <shape name="selectbar">
+                        <area>0,0,1830,69</area>
+                    </shape>
+                </state>
+                <state name="selectedinactive" from="active">
+                    <shape name="selectbar">
+                        <area>0,0,1830,69</area>
+                    </shape>
+                </state>
+            </statetype>
+
+            <statetype name="upscrollarrow">
+                <position>1740,697</position>
+            </statetype>
+
+            <statetype name="downscrollarrow">
+                <position>1785,697</position>
+            </statetype>
+        </buttonlist>
+
+
+    </window>
 
 </mythuitheme>

--- a/stream-ui.xml
+++ b/stream-ui.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE mythuitheme SYSTEM "http://www.mythtv.org/schema/mythuitheme.dtd">
-    <!-- patched -->
+
+<!-- This is based on v32 mythmusic/theme/default-wide/stream-ui.xml:
+     multipled 1.5 X, added transparent roundboxes from music-ui.xml,
+     share most of its infopanel, add clock, show 6 channels and 4
+     history, remove highlight from unselected lines. -->
 
 <mythuitheme>
 
     <window name="streamview"  include="music-base.xml">
 
         <shape name="streamlist_background" from="basebackground">
-            <area>22,22,1875,397</area>
+            <area>22,22,1875,391</area>
+            <type>roundbox</type>
+            <fill color="#000000" alpha="150" />
+            <line color="#FFFFFF" alpha="0" width="0" />
         </shape>
 
-        <shape name="playlist_background" from="basebackground">
-            <area>22,435,1875,255</area>
-        </shape>
-
-        <shape name="track_info_background" from="basebackground">
-            <area>22,705,1875,345</area>
+        <shape name="playlist_background" from="streamlist_background">
+            <area>22,432,1875,263</area>
         </shape>
 
         <textarea name="nostreams" from="basetextarea">
@@ -26,18 +29,22 @@
         </textarea>
 
         <buttonlist name="streamlist" from="basebuttonlist2">
-            <area>37,37,1837,375</area>
-            <spacing>0</spacing>
+            <area>37,37,1837,369</area>
+            <spacing>5</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
             <showarrow>no</showarrow>
-            <buttonarea>0,0,1225,230</buttonarea>
+            <buttonarea>0,0,1837,345</buttonarea>
             <statetype name="buttonitem">
                 <state name="active">
-                    <area>0,0,100%,69</area>
-
+                    <area>0,0,100%,52</area>
+                    <shape name="buttonbackground">
+                      <type>roundbox</type>
+                      <area>0,0,100%,95%</area>
+                      <fill color="#333333" alpha="0" />
+                    </shape>
                     <imagetype name="buttonimage">
-                        <area>7,7,54,54</area>
+                        <area>25,0,52,52</area>
                         <filename>mm_icecast.png</filename>
                     </imagetype>
 
@@ -52,30 +59,30 @@
                         </state>
                         <state name="paused">
                             <imagetype name="animation">
-                                <position>7,7</position>
+                                <position>25,0</position>
                                 <filename>mm_pauseicon.png</filename>
                             </imagetype>
                         </state>
                         <state name="stopped">
                             <imagetype name="animation">
-                                <position>7,7</position>
+                                <position>25,0</position>
                                 <filename>mm_stopicon.png</filename>
                             </imagetype>
                         </state>
                     </statetype>
 
-                    <textarea name="station" from="buttontext">
-                        <area>105,0,525,69</area>
+                    <textarea name="broadcaster" from="buttontext">
+                        <area>105,0,525,52</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
                     </textarea>
                     <textarea name="channel" from="buttontext">
-                        <area>645,0,555,69</area>
+                        <area>645,0,555,52</area>
                         <font>basesmall</font>
                         <align>left,vcenter</align>
                     </textarea>
                     <textarea name="genre" from="channel">
-                        <area>1215,0,555,69</area>
+                        <area>1215,0,555,52</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
                     </textarea>
@@ -83,16 +90,16 @@
                 </state>
                 <state name="selectedactive" from="active">
                     <imagetype name="buttonimage">
-                        <area>7,7,54,54</area>
+                        <area>25,0,52,52</area>
                         <filename>mm_icecast.png</filename>
                     </imagetype>
                     <shape name="selectbar">
-                        <area>0,0,100%,69</area>
+                        <area>0,0,100%,52</area>
                     </shape>
                 </state>
                 <state name="selectedinactive" from="active">
                     <shape name="selectbar">
-                        <area>0,0,100%,69</area>
+                        <area>0,0,100%,52</area>
                     </shape>
                 </state>
             </statetype>
@@ -105,41 +112,45 @@
         </buttonlist>
 
         <buttonlist name="playedtrackslist" from="basebuttonlist2">
-            <area>37,450,1837,225</area>
-            <spacing>0</spacing>
+            <area>37,447,1837,233</area>
+            <spacing>5</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
             <showarrow>no</showarrow>
-            <buttonarea>0,0,1225,150</buttonarea>
+            <buttonarea>0,0,1837,225</buttonarea>
             <statetype name="buttonitem">
                 <state name="active">
-                    <area>0,0,100%,69</area>
-
+                    <area>0,0,100%,52</area>
+                    <shape name="buttonbackground">
+                      <type>roundbox</type>
+                      <area>0,0,100%,95%</area>
+                      <fill color="#333333" alpha="0" />
+                    </shape>
                     <imagetype name="buttonimage">
-                        <area>7,7,54,54</area>
+                        <area>25,0,52,52</area>
                         <filename>mm_icecast.png</filename>
                     </imagetype>
 
                     <textarea name="tracknum" from="buttontext">
-                        <area>75,0,75,69</area>
+                        <area>75,0,100,52</area>
                         <align>right,vcenter</align>
                         <template>%1 -</template>
                     </textarea>
 
                     <textarea name="title" from="buttontext">
-                        <area>165,0,675,69</area>
+                        <area>190,0,675,52</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
                     </textarea>
 
                     <textarea name="artist" from="buttontext">
-                        <area>855,0,720,69</area>
+                        <area>880,0,720,52</area>
                         <font>basesmall</font>
                         <align>left,vcenter</align>
                     </textarea>
 
                     <textarea name="length" from="artist">
-                        <area>1590,0,180,69</area>
+                        <area>1600,0,180,52</area>
                         <align>right,vcenter</align>
                         <font>basesmall</font>
                     </textarea>
@@ -147,235 +158,190 @@
                 </state>
                 <state name="selectedactive" from="active">
                     <imagetype name="buttonimage">
-                        <area>7,7,54,54</area>
+                        <area>25,0,52,52</area>
                         <filename>mm_icecast.png</filename>
                     </imagetype>
                     <shape name="selectbar">
-                        <area>0,0,100%,69</area>
+                        <area>0,0,100%,52</area>
                     </shape>
                 </state>
                 <state name="selectedinactive" from="active">
                     <shape name="selectbar">
-                        <area>0,0,100%,69</area>
+                        <area>0,0,100%,52</area>
                     </shape>
                 </state>
             </statetype>
             <statetype name="upscrollarrow">
-                <position>1710,202</position>
+                <position>1710,215</position>
             </statetype>
             <statetype name="downscrollarrow">
-                <position>1770,202</position>
+                <position>1770,215</position>
             </statetype>
         </buttonlist>
 
-        <imagetype name="mm_blackhole_border">
-            <filename>mm_blackhole_border.png</filename>
-            <area>48,733,243,243</area>
-        </imagetype>
+    <group name="streaminfopanel" from="baseinfopanel">
 
-        <textarea name="title" from="basetextarea">
-            <area>345,727,1350,51</area>
-            <font>baselarge</font>
+        <!-- replace album with channel to re-use infopanel -->
+
+        <textarea name="album" from="basetextarea">
+            <template></template>
         </textarea>
-
-        <textarea name="artist" from="basetextarea">
-            <area>345,787,1350,51</area>
+      
+       <textarea name="channel" from="basetextarea">
+            <area>345,127,1300,51</area>
             <font>basemedium</font>
-        </textarea>
-
-        <textarea name="channel" from="basetextarea">
-            <area>345,840,1350,51</area>
-            <font>basemedium</font>
-            <template>%STATION% - %CHANNEL%</template>
+            <template>%BROADCASTER| - %%CHANNEL%</template>
         </textarea>
 
         <textarea name="url" from="basetextarea">
             <font>basesmall</font>
-            <area>345,892,1260,52</area>
+            <area>345,217,1300,52</area>
         </textarea>
 
-        <progressbar name="bufferprogress">
-            <position>345,1005</position>
-            <layout>horizontal</layout>
-           <style>reveal</style>
-            <imagetype name="background">
-                <filename>mm_progress-bg.png</filename>
-            </imagetype>
-            <imagetype name="progressimage">
-                <filename>mm_progress-fg.png</filename>
-            </imagetype>
-        </progressbar>
-
-        <textarea name="bufferstatus" from="basetextarea">
-            <area>345,967,600,52</area>
-            <font>basesmall</font>
-            <value></value>
-        </textarea>
-
-        <imagetype name="visualizer_border">
-            <filename>mm_blackhole_border.png</filename>
-            <area>1623,733,243,243</area>
-        </imagetype>
-
-        <video name="visualizer">
-            <area>1627,739,234,232</area>
-        </video>
-
-        <textarea name="visualizername" from="basetextarea">
-            <area>1627,975,234,52</area>
-            <font>basesmall</font>
-            <align>center</align>
-        </textarea>
-
-        <textarea name="volume" from="basevolume">
-            <position>105,1000</position>
-        </textarea>
-
-        <statetype name="mutestate" from="basemutestate">
-            <position>45,1005</position>
-        </statetype>
-
-        <imagetype name="coverart">
-            <filename>mm_nothumb.png</filename>
-            <area>52,739,234,232</area>
-        </imagetype>
+        <clock name="clock">
+            <area>800,260,570,90</area>
+            <font>baselarge</font>
+            <align>top,center</align>
+            <template>%DATE%, %TIME%</template>
+        </clock>
 
         <button name="play" from="baseplaybutton">
-            <position>1260,975</position>
+            <position>1430,270</position>
         </button>
 
         <button name="stop" from="basestopbutton">
-            <position>1327,975</position>
+            <position>1500,270</position>
         </button>
 
+    </group>
     </window>
 
     <window name="editstreammetadata">
 
         <textarea name="title" from="basetextarea">
-            <area>50,5,1837,50</area>
+            <area>22,7,1200,75</area>
             <font>baselarge</font>
             <value>Add/Edit Music Stream</value>
         </textarea>
 
         <textarea name="broadcasterlabel" >
-            <area>20,103,350,50</area>
+            <area>30,75,375,45</area>
             <font>basemedium</font>
             <align>right,vcenter</align>
-            <value>Station:</value>
+            <value>Broadcaster:</value>
         </textarea>
         <textedit name="broadcasteredit" from="basetextedit">
-            <position>410,103</position>
+            <position>420,75</position>
         </textedit>
 
         <button name="searchbutton" from="basewidebutton">
-            <position>1200,98</position>
+            <position>1260,78</position>
             <value>Search for Stream</value>
         </button>
 
         <textarea name="channellabel" from="broadcasterlabel">
-            <position>20,165</position>
+            <position>30,157</position>
             <value>Channel:</value>
         </textarea>
         <textedit name="channeledit" from="broadcasteredit">
-            <position>410,165</position>
+            <position>420,157</position>
         </textedit>
 
         <textarea name="descriptionlabel" from="broadcasterlabel">
-            <position>20,225</position>
+            <position>30,240</position>
             <value>Description:</value>
         </textarea>
         <textedit name="descriptionedit" from="broadcasteredit">
-            <area>410,225,970,50</area>
+            <area>420,240,1455,75</area>
         </textedit>
 
         <textarea name="urllabel" from="broadcasterlabel">
-            <position>20,285</position>
+            <position>30,322</position>
             <value>URL 1:</value>
         </textarea>
         <textedit name="url1edit" from="descriptionedit">
-            <position>410,285</position>
+            <position>420,322</position>
         </textedit>
 
         <textarea name="url2label" from="broadcasterlabel">
-            <position>20,345</position>
+            <position>30,405</position>
             <value>URL 2:</value>
         </textarea>
         <textedit name="url2edit" from="descriptionedit">
-            <position>410,345</position>
+            <position>420,405</position>
         </textedit>
 
         <textarea name="url3label" from="broadcasterlabel">
-            <position>20,405</position>
+            <position>30,487</position>
             <value>URL 3:</value>
         </textarea>
         <textedit name="url3edit" from="descriptionedit">
-            <position>410,405</position>
+            <position>420,487</position>
         </textedit>
 
         <textarea name="url4label" from="broadcasterlabel">
-            <position>20,465</position>
+            <position>30,570</position>
             <value>URL 4:</value>
         </textarea>
         <textedit name="url4edit" from="descriptionedit">
-            <position>410,465</position>
+            <position>420,570</position>
         </textedit>
 
         <textarea name="url5label" from="broadcasterlabel">
-            <position>20,525</position>
+            <position>30,652</position>
             <value>URL 5:</value>
         </textarea>
         <textedit name="url5edit" from="descriptionedit">
-            <position>410,525</position>
+            <position>420,652</position>
         </textedit>
 
         <textarea name="logourllabel" from="broadcasterlabel">
-            <position>20,585</position>
+            <position>30,735</position>
             <value>Logo URL:</value>
         </textarea>
         <textedit name="logourledit" from="descriptionedit">
-            <position>410,585</position>
-        </textedit>
-
-        <textarea name="countrylabel" from="broadcasterlabel">
-            <position>860,585</position>
-            <value>Country:</value>
-        </textarea>
-        <textedit name="countryedit" from="broadcasteredit">
-            <area>1250,585,320,50</area>
+            <position>420,735</position>
         </textedit>
 
         <textarea name="genrelabel" from="broadcasterlabel">
-            <position>20,645</position>
+            <position>30,817</position>
             <value>Genres:</value>
         </textarea>
         <textedit name="genreedit" from="broadcasteredit">
-            <position>410,645</position>
+            <position>420,817</position>
         </textedit>
 
-        <textarea name="languagelabel" from="broadcasterlabel">
-            <position>860,645</position>
-            <value>Language:</value>
+        <textarea name="countrylabel" from="broadcasterlabel">
+            <position>890,817</position>
+            <value>Country:</value>
         </textarea>
-        <textedit name="languageedit" from="countryedit">
-            <position>1250,645</position>
+        <textedit name="countryedit" from="broadcasteredit">
+            <area>1295,817,480,75</area>
         </textedit>
 
         <textarea name="formatlabel" from="broadcasterlabel">
-            <position>20,705</position>
+            <position>30,900</position>
             <value>Metadata Format:</value>
         </textarea>
         <textedit name="formatedit" from="broadcasteredit">
-            <position>410,705</position>
+            <position>420,900</position>
+        </textedit>
+
+        <textarea name="languagelabel" from="broadcasterlabel">
+            <position>890,900</position>
+            <value>Language:</value>
+        </textarea>
+        <textedit name="languageedit" from="countryedit">
+            <position>1295,900</position>
         </textedit>
 
         <button name="cancelbutton" from="basebutton">
-            <position>200,960</position>
+            <position>150,990</position>
             <value>Cancel</value>
         </button>
 
         <button name="savebutton" from="basebutton">
-            <position>1200,960</position>
+            <position>1500,990</position>
             <value>Save</value>
         </button>
 
@@ -390,76 +356,76 @@
         </textarea>
 
         <textarea name="broadcasterlabel" >
-            <area>4,80,310,50</area>
+            <area>66,72,315,45</area>
             <font>basemedium</font>
             <align>right,vcenter</align>
-            <value>Station:</value>
+            <value>Broadcaster:</value>
         </textarea>
         <buttonlist name="broadcasterlist" from="basemediumselector">
-            <position>330,81</position>
+            <position>390,76</position>
         </buttonlist>
 
-        <textarea name="countrylabel" >
-            <area>850,80,310,50</area>
-            <font>basemedium</font>
-            <align>right,vcenter</align>
+        <textarea name="countrylabel" from="broadcasterlabel">
+            <position>975,72</position>
             <value>Country:</value>
         </textarea>
         <buttonlist name="countrylist" from="basemediumselector">
-            <position>1200,81</position>
+            <position>1305,76</position>
         </buttonlist>
 
         <textarea name="genrelabel" from="broadcasterlabel">
-            <position>4,162</position>
+            <position>66,154</position>
             <value>Genre:</value>
         </textarea>
         <buttonlist name="genrelist" from="basemediumselector">
-            <position>330,163</position>
+            <position>390,159</position>
         </buttonlist>
 
-        <textarea name="languagelabel" >
-            <area>850,162,310,50</area>
-            <font>basemedium</font>
-            <align>right,vcenter</align>
+        <textarea name="languagelabel" from="broadcasterlabel">
+            <position>975,154</position>
             <value>Language:</value>
         </textarea>
         <buttonlist name="languagelist" from="basemediumselector">
-            <position>1200,163</position>
+            <position>1305,159</position>
         </buttonlist>
 
         <textarea name="channellabel" from="broadcasterlabel">
-            <position>4,249</position>
+            <position>66,241</position>
             <value>Channel:</value>
         </textarea>
         <textedit name="channeledit" from="basetextedit">
-            <position>330,250</position>
+            <position>390,241</position>
         </textedit>
 
         <textarea name="matcheslable" from="broadcasterlabel">
-            <area>850,249,280,50</area>
-            <align>right,vcenter</align>
+            <position>975,241</position>
             <value>Matches:</value>
         </textarea>
+
         <textarea name="matchestext" from="broadcasterlabel">
-            <area>1200,250,350,50</area>
+            <area>1305,241,225,45</area>
             <align>left,vcenter</align>
             <value></value>
         </textarea>
 
         <buttonlist name="streamlist" from="basebuttonlist2">
-            <area>45,337,1830,1020</area>
+            <area>45,322,1830,750</area>
             <spacing>0</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
             <showarrow>no</showarrow>
             <searchposition>-1,50</searchposition>
-            <buttonarea>0,0,1220,680</buttonarea>
+            <buttonarea>0,0,1830,750</buttonarea>
             <statetype name="buttonitem">
                 <state name="active">
                     <area>0,0,100%,54</area>
-
+                    <shape name="buttonbackground">
+                      <type>roundbox</type>
+                      <area>0,0,100%,95%</area>
+                      <fill color="#333333" alpha="0" />
+                    </shape>
                     <imagetype name="buttonimage">
-                        <area>7,7,54,54</area>
+                        <area>55,0,52,52</area>
                         <filename>mm_icecast.png</filename>
                     </imagetype>
 
@@ -474,61 +440,62 @@
                     </statetype>
 
                     <textarea name="broadcasterchannel" from="buttontext">
-                        <area>75,0,1080,46</area>
+                        <area>170,0,877,52</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
-                     </textarea>
+                    </textarea>
 
                     <textarea name="genre" from="buttontext">
-                        <area>1000,0,725,46</area>
+                        <area>1000,0,540,52</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
                     </textarea>
 
                     <textarea name="language" from="buttontext">
-                        <area>1580,0,180,46</area>
+                        <area>1545,0,270,52</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
                     </textarea>
-                </state>
 
+                </state>
                 <state name="selectedactive" from="active">
                     <imagetype name="buttonimage">
-                        <area>7,7,54,54</area>
+                        <area>0,1,163,163</area>
                         <filename>mm_icecast.png</filename>
                     </imagetype>
                     <shape name="selectbar">
-                        <area>0,0,1830,54</area>
+                        <area>0,0,1830,165</area>
                     </shape>
+                    <textarea name="description" from="buttontext">
+                        <area>170,60,1800,97</area>
+                        <multiline>yes</multiline>
+                        <align>left,vcenter</align>
+                        <font>basesmaller</font>
+                        <cutdown>false</cutdown>
+                        <scroll direction="vertical" rate="8" returnrate="75" startdelay="10" returndelay="6" />
+                    </textarea>
                 </state>
                 <state name="selectedinactive" from="active">
                     <shape name="selectbar">
-                        <area>0,0,1830,54</area>
+                        <area>0,0,1830,165</area>
                     </shape>
-                </state>
-
-                <state name="selectedactive" from="active">
-                    <imagetype name="buttonimage">
-                        <area>7,7,54,54</area>
-                        <filename>mm_icecast.png</filename>
-                    </imagetype>
-                    <shape name="selectbar">
-                        <area>0,0,1830,54</area>
-                    </shape>
-                </state>
-                <state name="selectedinactive" from="active">
-                    <shape name="selectbar">
-                        <area>0,0,1830,54</area>
-                    </shape>
+                    <textarea name="description" from="buttontext">
+                        <area>170,60,1800,97</area>
+                        <multiline>yes</multiline>
+                        <align>left,vcenter</align>
+                        <font>basesmaller</font>
+                        <cutdown>false</cutdown>
+                        <scroll direction="vertical" rate="8" returnrate="75" startdelay="10" returndelay="6" />
+                    </textarea>
                 </state>
             </statetype>
 
             <statetype name="upscrollarrow">
-                <position>1740,697</position>
+                <position>1740,720</position>
             </statetype>
 
             <statetype name="downscrollarrow">
-                <position>1785,697</position>
+                <position>1785,720</position>
             </statetype>
         </buttonlist>
 

--- a/stream-ui.xml
+++ b/stream-ui.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE mythuitheme SYSTEM "http://www.mythtv.org/schema/mythuitheme.dtd">
+    <!-- patched -->
 
 <mythuitheme>
 
@@ -252,73 +253,129 @@
     <window name="editstreammetadata">
 
         <textarea name="title" from="basetextarea">
-            <area>22,7,1200,75</area>
+            <area>50,5,1837,50</area>
             <font>baselarge</font>
             <value>Add/Edit Music Stream</value>
         </textarea>
 
-        <textarea name="stationlabel" >
-            <area>246,159,375,75</area>
+        <textarea name="broadcasterlabel" >
+            <area>20,103,350,50</area>
             <font>basemedium</font>
             <align>right,vcenter</align>
             <value>Station:</value>
         </textarea>
-        <textedit name="stationedit" from="basetextedit">
-            <position>636,159</position>
+        <textedit name="broadcasteredit" from="basetextedit">
+            <position>410,103</position>
         </textedit>
 
         <button name="searchbutton" from="basewidebutton">
-            <position>1260,162</position>
+            <position>1200,98</position>
             <value>Search for Stream</value>
         </button>
 
-        <textarea name="channellabel" from="stationlabel">
-            <position>246,249</position>
+        <textarea name="channellabel" from="broadcasterlabel">
+            <position>20,165</position>
             <value>Channel:</value>
         </textarea>
-        <textedit name="channeledit" from="stationedit">
-            <position>636,249</position>
+        <textedit name="channeledit" from="broadcasteredit">
+            <position>410,165</position>
         </textedit>
 
-        <textarea name="urllabel" from="stationlabel">
-            <position>246,339</position>
-            <value>URL:</value>
+        <textarea name="descriptionlabel" from="broadcasterlabel">
+            <position>20,225</position>
+            <value>Description:</value>
         </textarea>
-        <textedit name="urledit" from="stationedit">
-            <area>636,339,1050,75</area>
+        <textedit name="descriptionedit" from="broadcasteredit">
+            <area>410,225,970,50</area>
         </textedit>
 
-        <textarea name="logourllabel" from="stationlabel">
-            <position>246,429</position>
+        <textarea name="urllabel" from="broadcasterlabel">
+            <position>20,285</position>
+            <value>URL 1:</value>
+        </textarea>
+        <textedit name="url1edit" from="descriptionedit">
+            <position>410,285</position>
+        </textedit>
+
+        <textarea name="url2label" from="broadcasterlabel">
+            <position>20,345</position>
+            <value>URL 2:</value>
+        </textarea>
+        <textedit name="url2edit" from="descriptionedit">
+            <position>410,345</position>
+        </textedit>
+
+        <textarea name="url3label" from="broadcasterlabel">
+            <position>20,405</position>
+            <value>URL 3:</value>
+        </textarea>
+        <textedit name="url3edit" from="descriptionedit">
+            <position>410,405</position>
+        </textedit>
+
+        <textarea name="url4label" from="broadcasterlabel">
+            <position>20,465</position>
+            <value>URL 4:</value>
+        </textarea>
+        <textedit name="url4edit" from="descriptionedit">
+            <position>410,465</position>
+        </textedit>
+
+        <textarea name="url5label" from="broadcasterlabel">
+            <position>20,525</position>
+            <value>URL 5:</value>
+        </textarea>
+        <textedit name="url5edit" from="descriptionedit">
+            <position>410,525</position>
+        </textedit>
+
+        <textarea name="logourllabel" from="broadcasterlabel">
+            <position>20,585</position>
             <value>Logo URL:</value>
         </textarea>
-        <textedit name="logourledit" from="urledit">
-            <position>636,429</position>
+        <textedit name="logourledit" from="descriptionedit">
+            <position>410,585</position>
         </textedit>
 
-        <textarea name="genrelabel" from="stationlabel">
-            <position>246,519</position>
+        <textarea name="countrylabel" from="broadcasterlabel">
+            <position>860,585</position>
+            <value>Country:</value>
+        </textarea>
+        <textedit name="countryedit" from="broadcasteredit">
+            <area>1250,585,320,50</area>
+        </textedit>
+
+        <textarea name="genrelabel" from="broadcasterlabel">
+            <position>20,645</position>
             <value>Genres:</value>
         </textarea>
-        <textedit name="genreedit" from="urledit">
-            <position>636,519</position>
+        <textedit name="genreedit" from="broadcasteredit">
+            <position>410,645</position>
         </textedit>
 
-        <textarea name="formatlabel" from="stationlabel">
-            <position>246,609</position>
+        <textarea name="languagelabel" from="broadcasterlabel">
+            <position>860,645</position>
+            <value>Language:</value>
+        </textarea>
+        <textedit name="languageedit" from="countryedit">
+            <position>1250,645</position>
+        </textedit>
+
+        <textarea name="formatlabel" from="broadcasterlabel">
+            <position>20,705</position>
             <value>Metadata Format:</value>
         </textarea>
-        <textedit name="formatedit" from="stationedit">
-            <position>636,609</position>
+        <textedit name="formatedit" from="broadcasteredit">
+            <position>410,705</position>
         </textedit>
 
         <button name="cancelbutton" from="basebutton">
-            <position>150,975</position>
+            <position>200,960</position>
             <value>Cancel</value>
         </button>
 
         <button name="savebutton" from="basebutton">
-            <position>1500,975</position>
+            <position>1200,960</position>
             <value>Save</value>
         </button>
 
@@ -332,54 +389,75 @@
             <value>Search for Music Stream</value>
         </textarea>
 
-        <textarea name="stationlabel" >
-            <area>246,79,375,75</area>
+        <textarea name="broadcasterlabel" >
+            <area>4,80,310,50</area>
             <font>basemedium</font>
             <align>right,vcenter</align>
             <value>Station:</value>
         </textarea>
-        <buttonlist name="stationlist" from="basemediumselector">
-            <position>630,84</position>
+        <buttonlist name="broadcasterlist" from="basemediumselector">
+            <position>330,81</position>
         </buttonlist>
 
-        <textarea name="genrelabel" from="stationlabel">
-            <position>246,162</position>
+        <textarea name="countrylabel" >
+            <area>850,80,310,50</area>
+            <font>basemedium</font>
+            <align>right,vcenter</align>
+            <value>Country:</value>
+        </textarea>
+        <buttonlist name="countrylist" from="basemediumselector">
+            <position>1200,81</position>
+        </buttonlist>
+
+        <textarea name="genrelabel" from="broadcasterlabel">
+            <position>4,162</position>
             <value>Genre:</value>
         </textarea>
         <buttonlist name="genrelist" from="basemediumselector">
-            <position>630,166</position>
+            <position>330,163</position>
         </buttonlist>
 
-        <textarea name="channellabel" from="stationlabel">
-            <position>246,249</position>
+        <textarea name="languagelabel" >
+            <area>850,162,310,50</area>
+            <font>basemedium</font>
+            <align>right,vcenter</align>
+            <value>Language:</value>
+        </textarea>
+        <buttonlist name="languagelist" from="basemediumselector">
+            <position>1200,163</position>
+        </buttonlist>
+
+        <textarea name="channellabel" from="broadcasterlabel">
+            <position>4,249</position>
             <value>Channel:</value>
         </textarea>
         <textedit name="channeledit" from="basetextedit">
-            <position>630,249</position>
+            <position>330,250</position>
         </textedit>
 
-        <textarea name="matcheslable" from="stationlabel">
-            <area>1230,249,225,75</area>
+        <textarea name="matcheslable" from="broadcasterlabel">
+            <area>850,249,280,50</area>
             <align>right,vcenter</align>
             <value>Matches:</value>
         </textarea>
-
-        <textarea name="matchestext" from="stationlabel">
-            <area>1485,249,225,75</area>
+        <textarea name="matchestext" from="broadcasterlabel">
+            <area>1200,250,350,50</area>
             <align>left,vcenter</align>
+            <value></value>
         </textarea>
 
         <buttonlist name="streamlist" from="basebuttonlist2">
-            <area>45,337,1830,720</area>
+            <area>45,337,1830,1020</area>
             <spacing>0</spacing>
             <layout>vertical</layout>
             <arrange>stack</arrange>
             <showarrow>no</showarrow>
             <searchposition>-1,50</searchposition>
-            <buttonarea>0,0,1220,480</buttonarea>
+            <buttonarea>0,0,1220,680</buttonarea>
             <statetype name="buttonitem">
                 <state name="active">
-                    <area>0,0,100%,69</area>
+                    <area>0,0,100%,54</area>
+
                     <imagetype name="buttonimage">
                         <area>7,7,54,54</area>
                         <filename>mm_icecast.png</filename>
@@ -395,32 +473,52 @@
                         </state>
                     </statetype>
 
-                    <textarea name="station" from="buttontext">
-                        <area>75,0,900,69</area>
+                    <textarea name="broadcasterchannel" from="buttontext">
+                        <area>75,0,1080,46</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
-                        <template>%STATION% - %Channel%</template>
-                    </textarea>
+                     </textarea>
 
                     <textarea name="genre" from="buttontext">
-                        <area>990,0,825,69</area>
+                        <area>1000,0,725,46</area>
                         <align>left,vcenter</align>
                         <font>basesmall</font>
                     </textarea>
 
+                    <textarea name="language" from="buttontext">
+                        <area>1580,0,180,46</area>
+                        <align>left,vcenter</align>
+                        <font>basesmall</font>
+                    </textarea>
                 </state>
+
                 <state name="selectedactive" from="active">
                     <imagetype name="buttonimage">
                         <area>7,7,54,54</area>
                         <filename>mm_icecast.png</filename>
                     </imagetype>
                     <shape name="selectbar">
-                        <area>0,0,1830,69</area>
+                        <area>0,0,1830,54</area>
                     </shape>
                 </state>
                 <state name="selectedinactive" from="active">
                     <shape name="selectbar">
-                        <area>0,0,1830,69</area>
+                        <area>0,0,1830,54</area>
+                    </shape>
+                </state>
+
+                <state name="selectedactive" from="active">
+                    <imagetype name="buttonimage">
+                        <area>7,7,54,54</area>
+                        <filename>mm_icecast.png</filename>
+                    </imagetype>
+                    <shape name="selectbar">
+                        <area>0,0,1830,54</area>
+                    </shape>
+                </state>
+                <state name="selectedinactive" from="active">
+                    <shape name="selectbar">
+                        <area>0,0,1830,54</area>
                     </shape>
                 </state>
             </statetype>
@@ -433,7 +531,6 @@
                 <position>1785,697</position>
             </statetype>
         </buttonlist>
-
 
     </window>
 


### PR DESCRIPTION
Hello,

I made a few enhancements to music and stream:

* share most of infopanel from music-base to eliminate duplication
* scale stream-ui from default-wide by 1.5X to improve the edit and search list
* add track year to current track, selected track and info popups
* add track length to info popups
* change "title by artist on album" to "title \ artist \ album" to make it easier to see the parts (\ is not common in the metadata)
* add small scrollbar slider to long lists

Any objections to any of this?  Does it work for you too?

If we twiddle version to 30.3 in theminfo.xml does that make an update available to theme browser?  Or some other process?  Another option would be 32.0 since this is working with MythTV version 32.
